### PR TITLE
fix: Fix Line component cleanup function within condition

### DIFF
--- a/lib/components/Line.tsx
+++ b/lib/components/Line.tsx
@@ -23,7 +23,7 @@ const Line: React.FC<LineProps> = ({
   y0,
   x1,
   y1,
-  within = "",
+  within,
   borderColor,
   borderStyle,
   borderWidth,
@@ -44,9 +44,10 @@ const Line: React.FC<LineProps> = ({
     }
 
     const childElement = elRef.current;
+    const withinElement = withinRef.current;
     return () => {
-      if (childElement && withinRef.current) {
-        withinRef.current.removeChild(childElement);
+      if (childElement && withinElement) {
+        withinElement.removeChild(childElement);
       }
     };
   }, [within]);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-lineto-hooks",
   "private": false,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
Removed default assignment for 'within' prop and fixed the cleanup function by referencing 'withinRef' directly. This ensures that the element removal logic functions correctly when the 'within' prop is not provided.